### PR TITLE
[Refactor] Define Economy and Population interfaces

### DIFF
--- a/src/Capital.elm
+++ b/src/Capital.elm
@@ -1,0 +1,16 @@
+module Capital exposing (Capital)
+
+import Housing exposing (Housing)
+
+
+type alias Capital =
+    { housing : List Housing
+    , hospitalBeds : Int
+    , surgeons : Int
+    , openPrimaryEnrollment : Int
+    , openSecondaryEnrollment : Int
+    , openTertiaryEnrollment : Int
+    , food : Int
+    , clothing : Int
+    , prescriptionDrugs : Int
+    }

--- a/src/Job.elm
+++ b/src/Job.elm
@@ -1,5 +1,7 @@
-module Job exposing (Job, Title(..), description, generate, showTitle, train)
+module Job exposing (Job, Title(..), description, generate, showTitle, train, work)
 
+import Capital exposing (Capital)
+import Housing exposing (Housing)
 import Random exposing (Generator)
 
 
@@ -124,6 +126,49 @@ train title =
 
         Farmer ->
             { title = title, salary = 50000 }
+
+
+classSize : number
+classSize =
+    30
+
+
+work : Job -> Capital
+work job =
+    let
+        capital =
+            Capital [] 0 0 0 0 0 0 0 0
+    in
+    case job.title of
+        Farmer ->
+            { capital | food = 50 }
+
+        Doctor ->
+            { capital | surgeons = capital.surgeons + 1, prescriptionDrugs = capital.prescriptionDrugs + 1 }
+
+        Nurse ->
+            { capital | hospitalBeds = capital.hospitalBeds + 5, prescriptionDrugs = capital.prescriptionDrugs + 3 }
+
+        CivilEngineer ->
+            { capital | housing = [ Housing.buildHouse Housing.Urban ] }
+
+        Programmer ->
+            capital
+
+        SocialWorker ->
+            { capital | prescriptionDrugs = capital.prescriptionDrugs + 2 }
+
+        Teacher ->
+            { capital | openSecondaryEnrollment = capital.openSecondaryEnrollment + classSize }
+
+        Professor ->
+            { capital | openTertiaryEnrollment = capital.openTertiaryEnrollment + classSize }
+
+        Carpenter ->
+            capital
+
+        Electrician ->
+            capital
 
 
 generate : Generator Job

--- a/src/Job.elm
+++ b/src/Job.elm
@@ -1,7 +1,7 @@
 module Job exposing (Job, Title(..), description, generate, showTitle, train, work)
 
 import Capital exposing (Capital)
-import Housing exposing (Housing)
+import Housing
 import Random exposing (Generator)
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -436,8 +436,8 @@ updateGame rules msg ({ economy } as model) =
             let
                 product =
                     model.economy
-                        |> workPopulation model.population
                         |> Economy.produce model.population
+                        |> Economy.distribute model.population
             in
             ( { model
                 | population = Person.average (Time.posixToMillis posixTime) :: model.population
@@ -500,57 +500,6 @@ update rules msg page =
 score : Economy.Product -> Float
 score product =
     (product.avgHappiness + product.avgHealth / 2) * 100
-
-
-classSize : number
-classSize =
-    30
-
-
-workPerson : Economy -> Job -> Economy
-workPerson economy job =
-    case job.title of
-        Farmer ->
-            { economy | food = economy.food + 50 }
-
-        Doctor ->
-            { economy | surgeons = economy.surgeons + 1, prescriptionDrugs = economy.prescriptionDrugs + 1 }
-
-        Nurse ->
-            { economy | hospitalBeds = economy.hospitalBeds + 5, prescriptionDrugs = economy.prescriptionDrugs + 3 }
-
-        CivilEngineer ->
-            { economy | availableHousing = Housing.buildHouse Urban :: economy.availableHousing }
-
-        Programmer ->
-            economy
-
-        SocialWorker ->
-            { economy | prescriptionDrugs = economy.prescriptionDrugs + 2 }
-
-        Teacher ->
-            { economy | openSecondaryEnrollment = economy.openSecondaryEnrollment + classSize }
-
-        Professor ->
-            { economy | openTertiaryEnrollment = economy.openTertiaryEnrollment + classSize }
-
-        Carpenter ->
-            economy
-
-        Electrician ->
-            economy
-
-
-workPopulation : List Person -> Economy -> Economy
-workPopulation people economy =
-    List.foldl
-        (\person acc ->
-            person.job
-                |> Maybe.map (workPerson economy)
-                |> Maybe.withDefault acc
-        )
-        economy
-        people
 
 
 {-| A helper to make queries from a query syntax string. Make sure the syntax is

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -13,7 +13,7 @@ import GameTime
 import History exposing (Datum, History)
 import Housing exposing (Location(..))
 import Html exposing (Html)
-import Job exposing (Job, Title(..))
+import Job exposing (Title(..))
 import List
 import NarrativeEngine.Core.Rules as Rules
 import NarrativeEngine.Core.WorldModel as WorldModel

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -253,7 +253,7 @@ type alias Model =
     { worldModel : MyWorldModel
     , story : String
     , ruleCounts : Dict String Int
-    , population : List Person
+    , population : Population
     , economy : Economy
     , score : Float
     , happiness : Float
@@ -430,7 +430,7 @@ updateGame rules msg ({ economy } as model) =
             ( { model | economy = { economy | food = economy.food + 1 } }, Cmd.none )
 
         Train title ->
-            ( { model | population = train title model.population }, Cmd.none )
+            ( { model | population = Population.train title model.population }, Cmd.none )
 
         Tick posixTime ->
             let
@@ -512,25 +512,6 @@ query q worldModel =
         |> Result.withDefault []
 
 
-trainHelp : Job.Title -> List Person -> List Person -> List Person
-trainHelp title newPop population =
-    case population of
-        [] ->
-            newPop
-
-        person :: rest ->
-            if person.job == Nothing && Person.isQualified title person then
-                List.append newPop ({ person | job = Just (Job.train title) } :: rest)
-
-            else
-                trainHelp title (person :: newPop) rest
-
-
-train : Title -> List Person -> List Person
-train title population =
-    trainHelp title [] population
-
-
 
 -- VIEW
 
@@ -601,7 +582,7 @@ viewWorker title =
             \_ -> Element.none
 
 
-viewWorkforce : List Person -> Title -> Element Msg
+viewWorkforce : Population -> Title -> Element Msg
 viewWorkforce population title =
     row []
         (List.filterMap
@@ -623,18 +604,13 @@ clickerEconomy model =
         )
 
 
-canTrain : Job.Title -> List Person -> Bool
-canTrain title population =
-    List.any (\person -> person.job == Nothing && Person.isQualified title person) population
-
-
-trainButton : List Person -> Title -> Element Msg
+trainButton : Population -> Title -> Element Msg
 trainButton population title =
     let
         titleString =
             Job.showTitle title
     in
-    if canTrain title population then
+    if Population.canTrain title population then
         button [] { onPress = Just (Train title), label = text ("Train a " ++ titleString ++ " to " ++ Job.description title) }
 
     else
@@ -737,15 +713,15 @@ storyColumn model =
         ]
 
 
-ourDate : Date -> String
-ourDate date =
+formatDate : Date -> String
+formatDate date =
     GameTime.usFormat (Time.millisToPosix (Calendar.toMillis date))
 
 
 gameStats : Model -> Element Msg
 gameStats model =
     textColumn []
-        [ paragraph [] [ text ("Current Time: " ++ ourDate model.date) ]
+        [ paragraph [] [ text ("Current Time: " ++ formatDate model.date) ]
         , paragraph [] [ text ("Available Food: " ++ String.fromInt model.economy.food) ]
         ]
 

--- a/src/Person.elm
+++ b/src/Person.elm
@@ -68,6 +68,10 @@ average id =
     }
 
 
+
+-- QUERY
+
+
 housingScore : Person -> Float
 housingScore person =
     case person.house of

--- a/src/Population.elm
+++ b/src/Population.elm
@@ -1,11 +1,48 @@
-module Population exposing (Population, generate)
+module Population exposing (Population, canTrain, generate, train)
 
+import Job exposing (Title)
 import Person exposing (Person)
 import Random exposing (Generator)
 
 
 type alias Population =
     List Person
+
+
+
+-- QUERY
+
+
+canTrain : Job.Title -> Population -> Bool
+canTrain title population =
+    List.any (\person -> person.job == Nothing && Person.isQualified title person) population
+
+
+
+-- ALTER
+
+
+trainHelp : Job.Title -> Population -> Population -> Population
+trainHelp title newPop population =
+    case population of
+        [] ->
+            newPop
+
+        person :: rest ->
+            if person.job == Nothing && Person.isQualified title person then
+                List.append newPop ({ person | job = Just (Job.train title) } :: rest)
+
+            else
+                trainHelp title (person :: newPop) rest
+
+
+train : Title -> Population -> Population
+train title population =
+    trainHelp title [] population
+
+
+
+-- GENERATE
 
 
 generate : Generator Population

--- a/tests/EconomyTests.elm
+++ b/tests/EconomyTests.elm
@@ -70,7 +70,7 @@ suite =
                             { happiness = 1, health = 1 }
 
                         product =
-                            Economy.produce population economy
+                            Economy.distribute population economy
                     in
                     Expect.equal expected { happiness = product.avgHappiness, health = product.avgHealth }
             , test "returns half the ideal score for a half-served population" <|
@@ -83,7 +83,7 @@ suite =
                             { happiness = 1, health = 0.5 }
 
                         product =
-                            Economy.produce population economy
+                            Economy.distribute population economy
                     in
                     Expect.equal expected { happiness = product.avgHappiness, health = product.avgHealth }
             ]

--- a/tests/EconomyTests.elm
+++ b/tests/EconomyTests.elm
@@ -35,31 +35,7 @@ economy =
 suite : Test
 suite =
     describe "The Economy module"
-        [ describe "Economy.provide"
-            [ test "tablates correct score for the average individual" <|
-                \_ ->
-                    let
-                        person =
-                            Person.average 1
-
-                        expectedService =
-                            { stats = Economy.idealStats
-                            , economy =
-                                { economy
-                                    | occupiedHousing = List.take 1 economy.availableHousing
-                                    , availableHousing = List.drop 1 economy.availableHousing
-                                    , food = economy.food - 1
-                                    , clothing = economy.clothing - 1
-                                    , prescriptionDrugs = economy.prescriptionDrugs - person.prescriptionsNeeded
-                                    , surgeons = economy.surgeons - person.surgeriesNeeded
-                                    , hospitalBeds = economy.hospitalBeds - boolToNum person.needsHospitalization
-                                }
-                            , person = { person | prescriptionsNeeded = 0, house = List.head economy.availableHousing }
-                            }
-                    in
-                    Expect.equal expectedService (Economy.provide person economy)
-            ]
-        , describe "Economy.produce"
+        [ describe "Economy.produce"
             [ test "returns ideal happiness and healthiness for a satisfied population" <|
                 \_ ->
                     let


### PR DESCRIPTION
* improve naming for economic functions. The dual is now `Economy.produce` and `Economy.distribute`
* introduce `Capital` 
  * this will enable jobs to contribute partially to joint projects.
  * Example: 1 wood and 1 steel will allow for housing to be added to the economy. 2 wood and 0 still will not